### PR TITLE
Implement basic image upload for messenger

### DIFF
--- a/client/src/http/index.js
+++ b/client/src/http/index.js
@@ -1,0 +1,5 @@
+import axios from 'axios'
+
+export const $host = axios.create({
+    baseURL: 'http://localhost:5000/api'
+})

--- a/client/src/http/messageAPI.js
+++ b/client/src/http/messageAPI.js
@@ -1,0 +1,8 @@
+import { $host } from './index'
+
+export const createMessage = async (formData) => {
+    const { data } = await $host.post('message', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+    })
+    return data
+}

--- a/client/src/pages/messenger/Messenger.jsx
+++ b/client/src/pages/messenger/Messenger.jsx
@@ -1,8 +1,27 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { createMessage } from '../../http/messageAPI'
 
-function Messenger() {
+const Messenger = () => {
+  const [file, setFile] = useState(null)
+
+  const selectFile = (e) => {
+    setFile(e.target.files[0])
+  }
+
+  const sendMessage = async () => {
+    const formData = new FormData()
+    if (file) {
+      formData.append('img', file)
+    }
+    await createMessage(formData)
+    setFile(null)
+  }
+
   return (
-    <div>Messenger</div>
+    <div>
+      <input type="file" accept="image/*" onChange={selectFile} />
+      <button onClick={sendMessage}>Send</button>
+    </div>
   )
 }
 

--- a/server/controllers/messageController.js
+++ b/server/controllers/messageController.js
@@ -1,0 +1,24 @@
+const {Message} = require('../models/models')
+const uuid = require('uuid')
+const path = require('path')
+const ApiError = require('../error/ApiError')
+
+class MessageController {
+    async create(req, res, next) {
+        try {
+            const {userId, chatId} = req.body
+            let fileName = null
+            if (req.files && req.files.img) {
+                const {img} = req.files
+                fileName = uuid.v4() + path.extname(img.name)
+                img.mv(path.resolve(__dirname, '..', 'static/messages', fileName))
+            }
+            const message = await Message.create({userId, chatId, files: fileName})
+            return res.json(message)
+        } catch (e) {
+            next(ApiError.badRequest(e.message))
+        }
+    }
+}
+
+module.exports = new MessageController()

--- a/server/controllers/messegeController.js
+++ b/server/controllers/messegeController.js
@@ -1,7 +1,0 @@
-class MessageController {
-    async registartion(req, res) {
-
-    }
-}
-
-module.exports = new MessageController()

--- a/server/routes/messageRouter.js
+++ b/server/routes/messageRouter.js
@@ -1,10 +1,7 @@
 const Router = require('express')
 const router = new Router()
-const newsController = require('../controllers/newsController')
+const messageController = require('../controllers/messageController')
 
-
-router.post('/registration', )
-router.post('/login', )
-router.get('/auth', )
+router.post('/', messageController.create)
 
 module.exports = router


### PR DESCRIPTION
## Summary
- add backend endpoint for messages with image upload
- clean up unused message controller
- wire up new messenger page with upload form
- create axios helpers for client
- prepare folder for message images

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in server *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68751d38cd24832bbfc851568322abe2