### PR TITLE
Enable image upload modal

### DIFF
--- a/client/src/components/messengerContent/MessengerContent.jsx
+++ b/client/src/components/messengerContent/MessengerContent.jsx
@@ -18,7 +18,7 @@ const MessengerContent = observer(({ chats, setChats, setChatData, chatData, oth
 	const { user } = useContext(Context)
 	const [isWriting, setIsWriting] = useState(false)
 	const [isModal, setIsModal] = useState(false)
-	const [files, setFiles] = useState(null)
+        const [files, setFiles] = useState([])
 	const [notReadMessages, setNotReadMessages] = useState([])
 	const [isOnline, setIsOnline] = useState(false)
 	const [lastTimeOnline, setLastTimeOnline] = useState('')
@@ -349,17 +349,17 @@ const MessengerContent = observer(({ chats, setChats, setChatData, chatData, oth
 					}
 				</TransitionGroup>
 
-				{/* <CSSTransition
-					in={true}
-					timeout={300}
-					classNames="create-anim"
-					unmountOnExit
-					mountOnEnter
-				>
-					<div className={style.content__modal} onClick={() => setIsModal(false)}>
-						<MessengerModalFiles setIsModal={setIsModal} />
-					</div>
-				</CSSTransition> */}
+                                <CSSTransition
+                                        in={isModal}
+                                        timeout={300}
+                                        classNames="create-anim"
+                                        unmountOnExit
+                                        mountOnEnter
+                                >
+                                        <div className={style.content__modal} onClick={() => setIsModal(false)}>
+                                                <MessengerModalFiles setIsModal={setIsModal} files={files} setFiles={setFiles} />
+                                        </div>
+                                </CSSTransition>
 
 				<CSSTransition
 					in={contextMenu.visible}
@@ -428,7 +428,20 @@ const MessengerContent = observer(({ chats, setChats, setChatData, chatData, oth
 						</svg>
 					</div>
 				</CSSTransition>
-				<MessengerInteraction chatData={chatData} setMessages={setMessages} isScrollBottom={isScrollBottom} windowChatRef={windowChat} setChatData={setChatData} setChats={setChats} replyMessage={replyMessage} setReplyMessage={setReplyMessage} inputRef={inputRef} setFiles={setFiles} files={files} />
+                                <MessengerInteraction
+                                        chatData={chatData}
+                                        setMessages={setMessages}
+                                        isScrollBottom={isScrollBottom}
+                                        windowChatRef={windowChat}
+                                        setChatData={setChatData}
+                                        setChats={setChats}
+                                        replyMessage={replyMessage}
+                                        setReplyMessage={setReplyMessage}
+                                        inputRef={inputRef}
+                                        setFiles={setFiles}
+                                        files={files}
+                                        setIsModal={setIsModal}
+                                />
 			</div>
 		</>
 	return (

--- a/client/src/components/messengerInteraction/MessengerInteraction.jsx
+++ b/client/src/components/messengerInteraction/MessengerInteraction.jsx
@@ -8,7 +8,7 @@ import { fetchPersonalChat, sendMessage } from '../../http/messengerAPI'
 import EmojiPicker from 'emoji-picker-react';
 import { useDebounce } from '../../hooks/useDebounce';
 import { checkDraft } from '../../http/draftAPI';
-const MessengerInteraction = observer(({ chatData, setMessages, isScrollBottom, windowChatRef, setChatData, setChats, replyMessage, setReplyMessage, inputRef, setFiles, files }) => {
+const MessengerInteraction = observer(({ chatData, setMessages, isScrollBottom, windowChatRef, setChatData, setChats, replyMessage, setReplyMessage, inputRef, setFiles, files, setIsModal }) => {
 	const [messageContent, setMessageContent] = useState('');
 	const [messageContentFull, setMessageContentFull] = useState('')
 	const [notEmpty, setNotEmpty] = useState(false)
@@ -236,8 +236,18 @@ const MessengerInteraction = observer(({ chatData, setMessages, isScrollBottom, 
 
 	return (
 		<div className={style.interaction}>
-			<label htmlFor='clip' className={style.interaction__clip}>
-				<input value={files} id='clip' name='clip' type="file" onClick={(e) => setFiles(e.target.files[0])} />
+                        <label htmlFor='clip' className={style.interaction__clip}>
+                                <input
+                                        multiple
+                                        id='clip'
+                                        name='clip'
+                                        type="file"
+                                        onChange={(e) => {
+                                                const selected = Array.from(e.target.files);
+                                                setFiles(selected);
+                                                if (selected.length) setIsModal(true);
+                                        }}
+                                />
 				<svg xmlns="http://www.w3.org/2000/svg" width="17" height="20" viewBox="0 0 17 20" fill="none">
 					<path d="M5.07719 20C4.07331 19.9988 3.09226 19.6992 2.25774 19.139C1.42322 18.5787 0.772615 17.7829 0.387958 16.8519C0.00330138 15.9208 -0.0981788 14.8963 0.0963145 13.9075C0.290808 12.9186 0.772565 12.0097 1.48084 11.2954L8.25162 4.49715C8.82311 3.92468 9.59768 3.6036 10.4049 3.60454C11.2122 3.60549 11.986 3.92838 12.5562 4.50219C13.1263 5.076 13.4461 5.85371 13.4452 6.66425C13.4442 7.47479 13.1227 8.25176 12.5512 8.82423L5.5192 15.8847C5.42581 15.9793 5.3147 16.0543 5.19229 16.1055C5.06987 16.1567 4.93857 16.1831 4.80595 16.1831C4.67334 16.1831 4.54204 16.1567 4.41962 16.1055C4.2972 16.0543 4.1861 15.9793 4.09271 15.8847C3.90561 15.6958 3.80059 15.4401 3.80059 15.1736C3.80059 14.9072 3.90561 14.6515 4.09271 14.4625L11.1749 7.40204C11.3681 7.2081 11.4766 6.94505 11.4766 6.67077C11.4766 6.39649 11.3681 6.13345 11.1749 5.93951C10.9818 5.74556 10.7198 5.63661 10.4466 5.63661C10.1734 5.63661 9.91145 5.74556 9.71829 5.93951L2.90732 12.7277C2.33314 13.3062 2.01073 14.0896 2.01073 14.9064C2.01073 15.7231 2.33314 16.5065 2.90732 17.085C3.49328 17.6426 4.26987 17.9534 5.07719 17.9534C5.8845 17.9534 6.66109 17.6426 7.24705 17.085L13.7064 10.5994C14.6642 9.63775 15.2023 8.33341 15.2023 6.97337C15.2023 5.61332 14.6642 4.30899 13.7064 3.34729C12.7486 2.3856 11.4495 1.84532 10.095 1.84532C8.74045 1.84532 7.44139 2.3856 6.48358 3.34729L2.51554 7.33143C2.32371 7.52003 2.06512 7.62438 1.79666 7.62155C1.5282 7.61871 1.27186 7.50891 1.08403 7.3163C0.8962 7.1237 0.792264 6.86406 0.79509 6.59451C0.797916 6.32496 0.907272 6.06758 1.0991 5.87899L5.11737 1.84441C6.47063 0.615756 8.24239 -0.0437542 10.0663 0.00225506C11.8902 0.0482643 13.6267 0.796274 14.9168 2.09161C16.2069 3.38695 16.9519 5.13054 16.9978 6.96184C17.0436 8.79315 16.3867 10.5721 15.163 11.9309L8.70367 18.4164C8.23737 18.913 7.67553 19.3094 7.05218 19.5816C6.42882 19.8538 5.75693 19.9962 5.07719 20Z" fill="#FCFCFC" />
 				</svg>

--- a/client/src/components/messengerModalFiles/MessengerModalFiles.jsx
+++ b/client/src/components/messengerModalFiles/MessengerModalFiles.jsx
@@ -3,23 +3,13 @@ import style from './messengerModalFiles.module.scss'
 import FunctionButton from '../functionButton/FunctionButton';
 import Cross from '../cross/Cross';
 
-const MessengerModalFiles = ({ setIsModal }) => {
+const MessengerModalFiles = ({ setIsModal, files = [], setFiles }) => {
 
-	const photos = [
-		{ img: "https://static-cse.canva.com/blob/846900/photo1502082553048f009c37129b9e1583341920812.jpeg" },
-		{ img: "https://static-cse.canva.com/blob/846900/photo1502082553048f009c37129b9e1583341920812.jpeg" },
-		{ img: "https://static-cse.canva.com/blob/846900/photo1502082553048f009c37129b9e1583341920812.jpeg" },
-		{ img: "https://static-cse.canva.com/blob/846900/photo1502082553048f009c37129b9e1583341920812.jpeg" },
-		{ img: "https://static-cse.canva.com/blob/846900/photo1502082553048f009c37129b9e1583341920812.jpeg" },
-		{ img: "https://static-cse.canva.com/blob/846900/photo1502082553048f009c37129b9e1583341920812.jpeg" },
-		{ img: "https://static-cse.canva.com/blob/846900/photo1502082553048f009c37129b9e1583341920812.jpeg" },
-		{ img: "https://static-cse.canva.com/blob/846900/photo1502082553048f009c37129b9e1583341920812.jpeg" },
-		{ img: "https://static-cse.canva.com/blob/846900/photo1502082553048f009c37129b9e1583341920812.jpeg" },
-	]
+        const photos = files.map(file => ({ img: URL.createObjectURL(file) }))
 
-	const photoBlockRef = useRef(null);
+        const photoBlockRef = useRef(null);
 
-	useEffect(() => {
+        useEffect(() => {
 		const photoGrid = photoBlockRef.current;
 		const photoItems = photoGrid.querySelectorAll(`.${style.block__img}`);
 		photoItems.forEach(element => {
@@ -44,8 +34,14 @@ const MessengerModalFiles = ({ setIsModal }) => {
 
 				}
 			}
-		}
-	}, [photos]);
+                }
+        }, [photos]);
+
+        useEffect(() => {
+                return () => {
+                        photos.forEach(p => URL.revokeObjectURL(p.img));
+                };
+        }, [photos]);
 	return (
 		<div ref={photoBlockRef} className={style.block}>
 			<div className={style.block__header}>
@@ -53,8 +49,17 @@ const MessengerModalFiles = ({ setIsModal }) => {
 
 
 				<h3 className={style.block__headerCount}>Добавлено {photos.length} фото</h3>
-				<label htmlFor='addFile' className={style.block__headerBtn}>
-					<input type="file" id='addFile' name='addFile' />
+                                <label htmlFor='addFile' className={style.block__headerBtn}>
+                                        <input
+                                                multiple
+                                                type="file"
+                                                id='addFile'
+                                                name='addFile'
+                                                onChange={(e) => {
+                                                        const selected = Array.from(e.target.files);
+                                                        setFiles([...files, ...selected]);
+                                                }}
+                                        />
 					<div className={style.block__headerBtnWrapper}>
 						<div className={style.block__headerBtnInner}>
 							<div className={style.block__headerBtnInnerIcon}>


### PR DESCRIPTION
## Summary
- open the attachment modal when selecting files
- pass modal controls through MessengerContent and MessengerInteraction
- show selected images in MessengerModalFiles

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688238f712ac832bb50f77bf9695a954